### PR TITLE
PD-1629 handle new service slice health response format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *.swp
 *.coverage
 *.eggs
+.vscode/

--- a/tests/commands/test_service.py
+++ b/tests/commands/test_service.py
@@ -1,0 +1,41 @@
+from re import match
+from unittest import TestCase
+from emcli.commands.service import ServiceCommand
+
+class TestServiceCommandMethods(TestCase):
+    
+    def test_get_health_summary_healthy(self):
+        (is_healthy, message) = ServiceCommand.get_health_summary('my-env', 'my-svc', 'blue', {
+            'desiredCount': 1,
+            'desiredAndHealthyCount': 1,
+            'undesiredCount': 0
+        })
+        assert is_healthy == True
+        assert message == 'the blue slice of my-svc in my-env is healthy'
+
+    def test_get_health_summary_unhealthy(self):
+        (is_healthy, message) = ServiceCommand.get_health_summary('my-env', 'my-svc', 'blue', {
+            'desiredCount': 9,
+            'desiredAndHealthyCount': 7,
+            'undesiredCount': 0
+        })
+        assert is_healthy == False
+        assert message == 'the blue slice of my-svc in my-env is not operating at capacity (7/9 healthy)'
+
+    def test_get_health_summary_undesired(self):
+        (is_healthy, message) = ServiceCommand.get_health_summary('my-env', 'my-svc', 'blue', {
+            'desiredCount': 1,
+            'desiredAndHealthyCount': 1,
+            'undesiredCount': 1
+        })
+        assert is_healthy == False
+        assert message == 'the blue slice of my-svc in my-env may be routing requests to 1 unintended instance'
+
+    def test_get_health_summary_unhealthy_and_undesired(self):
+        (is_healthy, message) = ServiceCommand.get_health_summary('my-env', 'my-svc', 'blue', {
+            'desiredCount': 3,
+            'desiredAndHealthyCount': 1,
+            'undesiredCount': 2
+        })
+        assert is_healthy == False
+        assert message == 'the blue slice of my-svc in my-env may be routing requests to 2 unintended instances and is not operating at capacity (1/3 healthy)'


### PR DESCRIPTION
This change modifies the following command:

```
envmgr get <service> health in <environment> <slice>
```

so that it handles responses from Environment Manager route **/services/{service}/health/{slice}** as updated by [this pull request](https://github.com/trainline/environment-manager/pull/248). The response schema is described in the Swagger document [here](https://github.com/Merlin-Taylor/environment-manager/blob/c2bbbafef4bf2b6a843f9c929eac832c9744fca3/server/api/swagger.yaml#L999)

https://jira.thetrainline.com/browse/PLATFORM-1629