### PR TITLE
check for ci mode in patch operations

### DIFF
--- a/emcli/__init__.py
+++ b/emcli/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) Trainline Limited, 2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-__version__ = '1.9.1'
+__version__ = '1.9.4'
 

--- a/emcli/commands/patch.py
+++ b/emcli/commands/patch.py
@@ -104,8 +104,11 @@ class PatchCommand(BaseCommand):
             self.show_result({}, message)
             return False
         else:
-            message.append('Do you want to continue? (y/n) ')
-            return confirm(message)
+            if self.opts.get('ci-mode'):
+                return True
+            else:
+                message.append('Do you want to continue? (y/n) ')
+                return confirm(message)
 
     def get_patch_requirements(self, cluster, env, from_ami=None, to_ami=None, whitelist=None, blacklist=None):
         # We're only interested in Windows as Linux instances auto-update


### PR DESCRIPTION
Patching operation would prompt the user for confirmation, even with `--ci-mode` enabled. Check in place for patch command now to remove prompt when in CI mode.