### PR TITLE
PD-325 publish environment-specific packages

### DIFF
--- a/emcli/__init__.py
+++ b/emcli/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) Trainline Limited, 2017. All rights reserved. See LICENSE.txt in the project root for license information.
 
-__version__ = '1.9.6'
+__version__ = '1.9.7-alpha1'
 

--- a/emcli/cli.py
+++ b/emcli/cli.py
@@ -95,7 +95,8 @@ Usage:
         [--host=<host_name>] 
         [--user=<user_name> --pass=<password>]
         [--verbose]
-    envmgr publish <file> as <service> <version> 
+    envmgr publish <file> as <service> <version>
+        [--env=<env>]
         [(--json | --ci-mode)] 
         [--host=<host_name>] 
         [--user=<user_name> --pass=<password>]

--- a/emcli/commands/publish.py
+++ b/emcli/commands/publish.py
@@ -13,6 +13,7 @@ class PublishCommand(BaseCommand):
         self._register('publish', self.publish_service_file)
 
     def publish_service_file(self, service, version, file):
+        env = self.opts.get('env')
         file_path = os.path.abspath(file)
         if not os.path.isfile(file_path):
             print("{0} is not a valid file".format(file))
@@ -21,7 +22,7 @@ class PublishCommand(BaseCommand):
         svc = Service(service) 
         file_size = self.convert_size(os.path.getsize(file_path))
         with open(file_path, 'rb') as file:
-            result = svc.publish(file, version)
+            result = svc.publish(file, version, env) if env else svc.publish(file, version)
         
         if result is True:
             self.show_result({'success':True}, '{0} {1} published {2}'.format(service, version, file_size))

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'semver',
         'appdirs',
         'progressbar2',
-        'envmgr-lib==0.2.1'
+        'envmgr-lib==0.3.0'
     ],
     setup_requires = pytest_runner,
     tests_require = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ TEST_COMMANDS = [
     ('get deploy status a2fbb0c0-ed4c-11e6-85b1',           'emcli.cli.DeployCommand.run'),
     ('wait-for deploy a2fbb0c0-ed4c-11e6-85b1',             'emcli.cli.DeployCommand.run'),
     ('publish build-22.zip as AcmeService 1.2.3',           'emcli.cli.PublishCommand.run'),
+    ('publish --env MyEnv build-22.zip as AcmeService 1.2.3',           'emcli.cli.PublishCommand.run'),
     ('toggle MyService in staging',                         'emcli.cli.ToggleCommand.run'),
     ('get upstream status for blue MyService in staging',   'emcli.cli.ToggleCommand.run'),
     ('wait-for toggle to blue MyService in staging',        'emcli.cli.ToggleCommand.run'),


### PR DESCRIPTION
Support publication of environment-specific packages using the Environment Manager API `/package-upload-url/{service}/{version}/{environment}`

https://jira.thetrainline.com/browse/PD-325