### PR TITLE
PLATFORM-7304 fix zero exit code on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Zero exit code when `wait-for ...` commands time out.
+
+[Unreleased]: https://github.com/trainline/envmgr-cli/compare/1.10.0...HEAD

--- a/emcli/__main__.py
+++ b/emcli/__main__.py
@@ -239,7 +239,6 @@ def main():
             logging.info('Running {0} command'.format(cmd))
             CommandClass = commands[cmd]
             command = CommandClass(options)
-            command.run()
-            return
+            return command.run()
 
     print("Unknown command")

--- a/emcli/commands/asg.py
+++ b/emcli/commands/asg.py
@@ -81,16 +81,15 @@ class AsgCommand(BaseCommand):
     def wait_for(self, env, name):
         start = time.time()
         timeout = int(self.opts.get('timeout', 0))
-        should_continue = True
-        while should_continue:
+        while True:
             elapsed = int(time.time() - start)
             if timeout is not 0 and elapsed > timeout:
                 self.show_result({}, "Timeout exceeded")
-                should_continue = False
+                return 1
             else:
                 is_ready = self.get_status(env, name)
                 if is_ready:
-                    return
+                    return 0
                 else:
                     time.sleep(10)
 

--- a/emcli/commands/base.py
+++ b/emcli/commands/base.py
@@ -86,7 +86,7 @@ class BaseCommand(object):
             (action, with_spinner) = command
             if with_spinner:
                 self.show_activity()
-            action(**self.cli_args)
+            return action(**self.cli_args)
         else:
             raise Exception('Unknown command')
 

--- a/emcli/commands/deploy.py
+++ b/emcli/commands/deploy.py
@@ -34,18 +34,17 @@ class DeployCommand(BaseCommand):
     def wait_for_deployment(self, deploy_id):
         start = time.time()
         timeout = int(self.opts.get('timeout', 0))
-        should_continue = True
-        while should_continue:
+        while True:
             elapsed = int(time.time() - start)
             if timeout is not 0 and elapsed > timeout:
                 self.show_result({}, "Timeout exceeded")
-                should_continue = False
+                return 1
             else:
                 result = self.get_deploy_status(deploy_id)
                 status = result.get('Value').get('Status')
                 if status == "Failed" and self.opts.get('ci-mode'):
                     sys.exit(1)
                 elif status == "Failed" or status == "Success":
-                    return
+                    return 0
                 else:
                     time.sleep(10)

--- a/emcli/commands/service.py
+++ b/emcli/commands/service.py
@@ -47,16 +47,15 @@ class ServiceCommand(BaseCommand):
     def wait_for_healthy_service(self, service, env, slice=None):
         start = time.time()
         timeout = int(self.opts.get('timeout', 0))
-        should_continue = True
-        while should_continue:
+        while True:
             elapsed = int(time.time() - start)
             if timeout is not 0 and elapsed > timeout:
                 self.show_result({}, "Timeout exceeded")
-                should_continue = False
+                return 1
             else:
                 healthy = self.get_service_health(service, env, slice)
                 if healthy:
-                    return
+                    return 0
                 else:
                     time.sleep(5)
     

--- a/emcli/commands/toggle.py
+++ b/emcli/commands/toggle.py
@@ -35,16 +35,14 @@ class ToggleCommand(BaseCommand):
     def wait_for_toggle(self, slice, service, env):
         start = time.time()
         timeout = int(self.opts.get('timeout', 0))
-        should_continue = True
-        while should_continue:
+        while True:
             elapsed = int(time.time() - start)
             if timeout is not 0 and elapsed > timeout:
                 self.show_result({}, "Timeout exceeded")
-                should_continue = False
+                return 1
             else:
                 status = self.get_upstream_status(slice, service, env)
                 if status.is_active:
-                    return
+                    return 0
                 else:
                     time.sleep(5)
-

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     entry_points = {
         'console_scripts': [
-            'envmgr=emcli.cli:main',
+            'envmgr=emcli.__main__:main',
         ],
     },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,35 +5,35 @@ import os
 
 from unittest import TestCase
 from mock import patch
-from emcli.cli import main, except_hook
+from emcli.__main__ import main, except_hook
 from parameterized import parameterized
 
 TEST_COMMANDS = [
-    ('get MockService health in prod',                      'emcli.cli.ServiceCommand.run'),
-    ('get AcmeService health in prod green',                'emcli.cli.ServiceCommand.run'),
-    ('get CoolService active slice in dev',                 'emcli.cli.ServiceCommand.run'),
-    ('get CoolService inactive slice in staging',           'emcli.cli.ServiceCommand.run'),
-    ('wait-for healthy CoolService in prod',                'emcli.cli.ServiceCommand.run'),
-    ('check asg mock-asg exists in prod',                   'emcli.cli.AsgCommand.run'),
-    ('get asg mock-asg status in prod',                     'emcli.cli.AsgCommand.run'),
-    ('get asg mock-asg schedule in staging',                'emcli.cli.AsgCommand.run'),
-    ('get asg mock-asg health in test',                     'emcli.cli.AsgCommand.run'),
-    ('wait-for asg mock-asg in prod',                       'emcli.cli.AsgCommand.run'),
-    ('set asg mock-asg schedule off in staging',            'emcli.cli.AsgCommand.run'),
-    ('get instances out of date by 30 days --env=prod',     'emcli.cli.InstanceCommand.run'),
-    ('deploy MyService 1.4.0 in prod',                      'emcli.cli.DeployCommand.run'),
-    ('get deploy status a2fbb0c0-ed4c-11e6-85b1',           'emcli.cli.DeployCommand.run'),
-    ('wait-for deploy a2fbb0c0-ed4c-11e6-85b1',             'emcli.cli.DeployCommand.run'),
-    ('publish build-22.zip as AcmeService 1.2.3',           'emcli.cli.PublishCommand.run'),
-    ('publish --env MyEnv build-22.zip as AcmeService 1.2.3',           'emcli.cli.PublishCommand.run'),
-    ('toggle MyService in staging',                         'emcli.cli.ToggleCommand.run'),
-    ('get upstream status for blue MyService in staging',   'emcli.cli.ToggleCommand.run'),
-    ('wait-for toggle to blue MyService in staging',        'emcli.cli.ToggleCommand.run'),
-    ('get A-team patch status in prod',                     'emcli.cli.PatchCommand.run'),
-    ('patch team in prod',                                  'emcli.cli.PatchCommand.run'),
-    ('get team asg cycle status in staging',                'emcli.cli.CycleCommand.run'),
-    ('cycle team asgs in prod',                             'emcli.cli.CycleCommand.run'),
-    ('verify',                                              'emcli.cli.VerifyCommand.run')
+    ('get MockService health in prod',                      'emcli.__main__.ServiceCommand.run'),
+    ('get AcmeService health in prod green',                'emcli.__main__.ServiceCommand.run'),
+    ('get CoolService active slice in dev',                 'emcli.__main__.ServiceCommand.run'),
+    ('get CoolService inactive slice in staging',           'emcli.__main__.ServiceCommand.run'),
+    ('wait-for healthy CoolService in prod',                'emcli.__main__.ServiceCommand.run'),
+    ('check asg mock-asg exists in prod',                   'emcli.__main__.AsgCommand.run'),
+    ('get asg mock-asg status in prod',                     'emcli.__main__.AsgCommand.run'),
+    ('get asg mock-asg schedule in staging',                'emcli.__main__.AsgCommand.run'),
+    ('get asg mock-asg health in test',                     'emcli.__main__.AsgCommand.run'),
+    ('wait-for asg mock-asg in prod',                       'emcli.__main__.AsgCommand.run'),
+    ('set asg mock-asg schedule off in staging',            'emcli.__main__.AsgCommand.run'),
+    ('get instances out of date by 30 days --env=prod',     'emcli.__main__.InstanceCommand.run'),
+    ('deploy MyService 1.4.0 in prod',                      'emcli.__main__.DeployCommand.run'),
+    ('get deploy status a2fbb0c0-ed4c-11e6-85b1',           'emcli.__main__.DeployCommand.run'),
+    ('wait-for deploy a2fbb0c0-ed4c-11e6-85b1',             'emcli.__main__.DeployCommand.run'),
+    ('publish build-22.zip as AcmeService 1.2.3',           'emcli.__main__.PublishCommand.run'),
+    ('publish --env MyEnv build-22.zip as AcmeService 1.2.3',           'emcli.__main__.PublishCommand.run'),
+    ('toggle MyService in staging',                         'emcli.__main__.ToggleCommand.run'),
+    ('get upstream status for blue MyService in staging',   'emcli.__main__.ToggleCommand.run'),
+    ('wait-for toggle to blue MyService in staging',        'emcli.__main__.ToggleCommand.run'),
+    ('get A-team patch status in prod',                     'emcli.__main__.PatchCommand.run'),
+    ('patch team in prod',                                  'emcli.__main__.PatchCommand.run'),
+    ('get team asg cycle status in staging',                'emcli.__main__.CycleCommand.run'),
+    ('cycle team asgs in prod',                             'emcli.__main__.CycleCommand.run'),
+    ('verify',                                              'emcli.__main__.VerifyCommand.run')
 ]
 
 og_getenv = os.getenv


### PR DESCRIPTION
When the following commands time out they now exit with a non-zero status:
- `envmgr wait-for deploy <deploy_id>`
- `envmgr wait-for healthy <service> in <env>`
- `envmgr wait-for asg <name> in <env>`
- `envmgr wait-for toggle to <slice> <service> in <env>`

https://jira.thetrainline.com/browse/PLATFORM-7304