### PR TITLE
fix/PD-394 pin all dependency versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@ build
 dist
 *.egg-info
 *.pyc
-.cache
 *.swp
 *.coverage
 *.eggs
-.vscode/
+.*
+!.appveyor.yml
+!.gitignore
+!.travis.yml

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(join(this_dir, 'README.rst'), encoding='utf-8') as file:
     long_description = file.read()
 
 needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner', 'nose'] if needs_pytest else []
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name = 'envmgr-cli',
@@ -25,22 +25,22 @@ setup(
     license = 'Apache 2.0',
     packages = find_packages(exclude=['tests*']),
     install_requires = [
-        'docopt',
-        'simplejson',
-        'tabulate',
-        'future',
-        'semver',
-        'appdirs',
-        'progressbar2',
+        'docopt~=0.6.2',
+        'simplejson~=3.11.1',
+        'tabulate~=0.7.7',
+        'future~=0.16.0',
+        'semver~=2.7.7',
+        'appdirs~=1.4.3',
+        'progressbar2~=3.30.2',
         'envmgr-lib==0.3.0'
     ],
     setup_requires = pytest_runner,
     tests_require = [
-        'pytest',
-        'mock',
-        'nose',
-        'nose-parameterized',
-        'responses'
+        'pytest~=3.0',
+        'mock~=2.0.0',
+        'nose~=1.3.7',
+        'parameterized~=0.6.1',
+        'responses~=0.5.1'
     ],
     entry_points = {
         'console_scripts': [

--- a/tests/commands/helpers/deploy_scenarios.py
+++ b/tests/commands/helpers/deploy_scenarios.py
@@ -1,6 +1,4 @@
-
-
-from nose_parameterized import param
+from parameterized import param
 
 DEPLOY_SCENARIOS = [
     (

--- a/tests/commands/helpers/patch_scenarios.py
+++ b/tests/commands/helpers/patch_scenarios.py
@@ -1,5 +1,4 @@
-    
-from nose_parameterized import param
+from parameterized import param
 
 LATEST_STABLE_WINDOWS_APP = 'windows-2012r2-app-7.3.2'
 LATEST_STABLE_WINDOWS_SECURE = 'windows-2012r2-secureapp-7.3.0'

--- a/tests/commands/test_patch.py
+++ b/tests/commands/test_patch.py
@@ -7,7 +7,7 @@ import os
 
 from unittest import TestCase
 from emcli.commands import PatchCommand
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 from mock import patch
 from .helpers.api_test_case import APITestCase
 from .helpers.utils import mock_server, MOCK_ENV_VARS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import os
 from unittest import TestCase
 from mock import patch
 from emcli.cli import main, except_hook
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 TEST_COMMANDS = [
     ('get MockService health in prod',                      'emcli.cli.ServiceCommand.run'),


### PR DESCRIPTION
[envmgr-cli 1.10.0](https://github.com/trainline/envmgr-cli/tree/1.10.0) built successfully on [2017-07-14 ](https://travis-ci.org/trainline/envmgr-cli/jobs/253542807) but a number of unit tests failed for the same revision built on [2017-09-05](https://travis-ci.org/trainline/envmgr-cli/builds/253542795). This PR pins all the dependencies to the latest minor versions as at  2017-07-14.

- Pin dependency versions.
- Replace the deprecated _nose-parameterized_ package with _parameterized_.

https://jira.thetrainline.com/browse/PD-394