### PR TITLE
Add jq to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN \
 cd /build && \
 python setup.py install && \
 rm -rf /build
+RUN apk add --no-cache jq
 
 ENTRYPOINT []
 CMD ["envmgr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ADD setup.* README.rst /build/
 ADD emcli /build/emcli
 
 RUN \
-cd /build && \
-python setup.py install && \
+apk add --no-cache jq ;\
+cd /build ;\
+python setup.py install ;\
 rm -rf /build
-RUN apk add --no-cache jq
 
 ENTRYPOINT []
 CMD ["envmgr"]


### PR DESCRIPTION
Add `jq` to the docker image to allow parsing JSON output within build pipelines, etc.