### PR TITLE
lambda was being called with a single item of the dictionary, rather …

### DIFF
--- a/emcli/commands/asg.py
+++ b/emcli/commands/asg.py
@@ -71,10 +71,10 @@ class AsgCommand(BaseCommand):
         if is_ready:
             self.show_result(result, "{0} is ready for deployments".format(name))
         else:
-            n_total = result.get('InstancesTotalCount')
-            states = map(lambda state,count: "{0}={1}".format(state, count), 
-                    result.get('InstancesByLifecycleState').iteritems())
-            self.show_result(result, "{0} is not ready for deployment (instances: {1}, Total={2})".format(name, ", ".join(states), n_total))
+            states = []
+            for state, count in result.get('InstancesByLifecycleState').iteritems():
+                states.append("{0}={1}".format(state, count))
+            self.show_result(result, "{0} is not ready for deployment (instances: {1}, Total={2})".format(name, ", ".join(states), len(states)))
 
         return is_ready 
 


### PR DESCRIPTION
…than the key, value pairs it would appear were expected.

The lambda was previously giving an error that it was being called with one argument when 2 were expected. The single argument it was being given was the dictionary from the `iteritems()` rather than destructuring to the key value pairs as it looks was the intention.  

Local testing on an ASG that is in a wait-for state shows this to output the expected values and loop as expected from a `wait-for` call. 