### PR TITLE
remove the check for undesired count on deployment

### DIFF
--- a/emcli/commands/service.py
+++ b/emcli/commands/service.py
@@ -78,7 +78,7 @@ class ServiceCommand(BaseCommand):
         desired_and_healthy_count = summary.get('desiredAndHealthyCount')
         undesired_count = summary.get('undesiredCount')
         service_name = "the {0} slice of {1} in {2}".format(slice, service, env)
-        is_healthy = desired_and_healthy_count >= desired_count and undesired_count <= 0
+        is_healthy = desired_and_healthy_count >= desired_count
         messages = filter(lambda x: x != None, [
             "is healthy" if is_healthy else None,
             "may be routing requests to {0} unintended instance{1}".format(undesired_count, "s" if undesired_count > 1 else "") if undesired_count > 0 else None,

--- a/tests/commands/test_service.py
+++ b/tests/commands/test_service.py
@@ -28,8 +28,8 @@ class TestServiceCommandMethods(TestCase):
             'desiredAndHealthyCount': 1,
             'undesiredCount': 1
         })
-        assert is_healthy == False
-        assert message == 'the blue slice of my-svc in my-env may be routing requests to 1 unintended instance'
+        assert is_healthy == True
+        assert message == 'the blue slice of my-svc in my-env is healthy and may be routing requests to 1 unintended instance'
 
     def test_get_health_summary_unhealthy_and_undesired(self):
         (is_healthy, message) = ServiceCommand.get_health_summary('my-env', 'my-svc', 'blue', {


### PR DESCRIPTION
The undesired count check is performed against a deploymet *only* from the CLI. This does not need to be checked (here!) and if the check is required (was required) we should add it to the deployments API. 